### PR TITLE
Add Colab audio denoising notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# Audiodenoise_on_Colab
+# Audiodenoise on Colab
+
+這個專案提供一個可以在 Google Colab 上執行的 AI 語音降噪筆記本，利用 GPU 加速並透過表單選項操作。
+
+## 功能
+
+- 使用 [SpeechBrain](https://github.com/speechbrain/speechbrain) 的 MetricGAN+ 模型進行語音降噪。
+- 從 Google Drive 讀取影片或聲音檔案，輸出為 WAV 音訊檔。
+- 掛載 Google Drive，支援 GPU 推論。
+- 利用 Colab 表單輸入路徑與設定，操作簡單。
+- 可指定整個資料夾進行批次處理，已存在的輸出檔案會被跳過。
+
+## 使用方式
+
+1. 於 GitHub 或本地環境開啟 [audiodenoise_colab.ipynb](audiodenoise_colab.ipynb) 並連線至 Google Colab。
+2. 在第一個表單中安裝相依套件並掛載 Google Drive。
+3. 在第二個表單填入來源檔案或資料夾，以及輸出路徑；可選擇是否使用 GPU。若來源為資料夾，輸出路徑視為資料夾，會依序處理其中的影音檔案，並跳過已存在的輸出檔。
+4. 在第三個表單執行降噪，結果將儲存至指定的 Google Drive 路徑。
+
+輸出檔案格式為單聲道 WAV，取樣率 16 kHz。

--- a/audiodenoise_colab.ipynb
+++ b/audiodenoise_colab.ipynb
@@ -1,0 +1,116 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# AI 語音降噪 Colab\n",
+    "這個 Colab 筆記本會使用 [SpeechBrain](https://github.com/speechbrain/speechbrain) 的 MetricGAN+ 模型，使用 GPU 進行語音降噪。\n",
+    "\n",
+    "載入 Google Drive 中的影音或聲音檔案，並將結果產生為聲音檔 (.wav)。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "#@title 1. 安裝相依套件並掛載雲端硬碟\n",
+    "!pip install -q speechbrain torchaudio ffmpeg-python\n",
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "#@title 2. 設定來源檔案或資料夾與輸出路徑\n",
+    "input_path = '/content/drive/MyDrive/input.mp4'  #@param {type:'string'}\n",
+    "output_path = '/content/drive/MyDrive/output'  #@param {type:'string'}\n",
+    "use_gpu = True  #@param {type:'boolean'}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "#@title 3. 執行降噪\n",
+    "import os, glob, subprocess, torch, torchaudio\n",
+    "from speechbrain.pretrained.interfaces import SpectralMaskEnhancement\n",
+    "\n",
+    "video_exts = ['.mp4','.mov','.avi','.mkv','.flv','.webm']\n",
+    "audio_exts = ['.wav','.mp3','.flac','.ogg','.m4a']\n",
+    "\n",
+    "def extract_audio(src, dst):\n",
+    "    subprocess.run(['ffmpeg','-y','-i', src, '-vn','-ac','1', dst], check=True)\n",
+    "\n",
+    "def denoise_file(src, dst, enhancer):\n",
+    "    tmp_wav = '/content/tmp_input.wav'\n",
+    "    ext = os.path.splitext(src)[1].lower()\n",
+    "    if ext in video_exts:\n",
+    "        extract_audio(src, tmp_wav)\n",
+    "        processed_input = tmp_wav\n",
+    "    else:\n",
+    "        processed_input = src\n",
+    "    enhanced = enhancer.enhance_file(processed_input)\n",
+    "    torchaudio.save(dst, enhanced.squeeze(0), 16000)\n",
+    "    if processed_input == tmp_wav and os.path.exists(tmp_wav):\n",
+    "        os.remove(tmp_wav)\n",
+    "\n",
+    "device = 'cuda' if (use_gpu and torch.cuda.is_available()) else 'cpu'\n",
+    "enhancer = SpectralMaskEnhancement.from_hparams(\n",
+    "    source='speechbrain/metricgan-plus-voicebank',\n",
+    "    savedir='pretrained_models/metricgan-plus-voicebank',\n",
+    "    run_opts={'device': device}\n",
+    ")\n",
+    "\n",
+    "if os.path.isdir(input_path):\n",
+    "    os.makedirs(output_path, exist_ok=True)\n",
+    "    candidates = glob.glob(os.path.join(input_path, '*'))\n",
+    "    files = [f for f in candidates if os.path.splitext(f)[1].lower() in video_exts + audio_exts]\n",
+    "    for f in sorted(files):\n",
+    "        out_file = os.path.join(output_path, os.path.splitext(os.path.basename(f))[0] + '.wav')\n",
+    "        if os.path.exists(out_file):\n",
+    "            print('跳過已存在的輸出檔案', out_file)\n",
+    "            continue\n",
+    "        denoise_file(f, out_file, enhancer)\n",
+    "        print('已處理', f)\n",
+    "else:\n",
+    "    if os.path.exists(output_path):\n",
+    "        print('輸出檔案已存在，跳過', output_path)\n",
+    "    else:\n",
+    "        denoise_file(input_path, output_path, enhancer)\n",
+    "        print('已處理', input_path)\n",
+    "\n",
+    "print('處理完成')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "name": "audiodenoise_colab.ipynb"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Summary
- add Colab notebook for GPU speech denoising with SpeechBrain
- document usage and Google Drive workflow
- support batch processing of folders and skip existing outputs

## Testing
- `python - <<'PY'
import nbformat
nbformat.read('audiodenoise_colab.ipynb', as_version=4)
print('notebook ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6896dc5666e88331b80d77ec42a2e206